### PR TITLE
hook handles scopes and version specs

### DIFF
--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
-current_package='\["'${npm_package_name:?}'("\]|@)'
+main_package() {
+  local current_package='\["'${npm_package_name:?}'("\]|@)'
 
-if [[ ! ${npm_config_argv:?} =~ $current_package ]]; then
+  [[ ${npm_config_argv:?} =~ $current_package ]]
+}
+
+# This hook gets invoked when installing dependencies, too, but
+# we only care about the "main" package installed specifically by the user.
+# That way we only rehash once for a global install, not hundreds of times.
+if ! main_package; then
   exit
 fi
 

--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-if [[ ! ${npm_config_argv:?} =~ \[\"${npm_package_name:?}\"\] ]]; then
+current_package='\["'${npm_package_name:?}'("\]|@)'
+
+if [[ ! ${npm_config_argv:?} =~ $current_package ]]; then
   exit
 fi
 

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -6,9 +6,11 @@ libexec=${BATS_TEST_DIRNAME}/../libexec
 
 fake_env_for_npm() {
   export npm_lifecycle_event=post$1
-  export npm_package_name=${2%@*}
-  export npm_package_version=${2#*@}
-  export npm_config_argv='{"remain":["'$2'"],"cooked":["i","--global","'$2'"],"original":["i","-g","'$2'"]}'
+  export npm_package_name=$2
+  export npm_package_version=$3
+
+  local p=$2${3+@$3}
+  export npm_config_argv='{"remain":["'$p'"],"cooked":["i","--global","'$p'"],"original":["i","-g","'$p'"]}'
 }
 
 @test "npm hook rehashes for the 'main' package" {
@@ -31,4 +33,37 @@ fake_env_for_npm() {
 
   assert_success
   refute_output
+}
+
+@test "npm hook handles installs specifying version or dist-tag" {
+  stub nodenv 'rehash : echo "rehashing"'
+  fake_env_for_npm install testdouble latest
+
+  run ./libexec/nodenv-rehash
+
+  assert_success
+  assert_output "rehashing"
+  unstub nodenv
+}
+
+@test "npm hook handles package with @org scope" {
+  stub nodenv 'rehash : echo "rehashing"'
+  fake_env_for_npm install @org/testdouble
+
+  run ./libexec/nodenv-rehash
+
+  assert_success
+  assert_output "rehashing"
+  unstub nodenv
+}
+
+@test "npm hook handles package with @org scope and version/dist-tag" {
+  stub nodenv 'rehash : echo "rehashing"'
+  fake_env_for_npm install @org/testdouble latest
+
+  run ./libexec/nodenv-rehash
+
+  assert_success
+  assert_output "rehashing"
+  unstub nodenv
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -14,13 +14,12 @@ fake_env_for_npm() {
 }
 
 @test "npm hook rehashes for the 'main' package" {
-  stub nodenv 'rehash : echo rehashing'
+  stub nodenv 'rehash : true'
   fake_env_for_npm install lineman
 
   run $libexec/nodenv-rehash
 
   assert_success
-  assert_output "rehashing"
   unstub nodenv
 }
 
@@ -36,34 +35,31 @@ fake_env_for_npm() {
 }
 
 @test "npm hook handles installs specifying version or dist-tag" {
-  stub nodenv 'rehash : echo "rehashing"'
+  stub nodenv 'rehash : true'
   fake_env_for_npm install testdouble latest
 
   run ./libexec/nodenv-rehash
 
   assert_success
-  assert_output "rehashing"
   unstub nodenv
 }
 
 @test "npm hook handles package with @org scope" {
-  stub nodenv 'rehash : echo "rehashing"'
+  stub nodenv 'rehash : true'
   fake_env_for_npm install @org/testdouble
 
   run ./libexec/nodenv-rehash
 
   assert_success
-  assert_output "rehashing"
   unstub nodenv
 }
 
 @test "npm hook handles package with @org scope and version/dist-tag" {
-  stub nodenv 'rehash : echo "rehashing"'
+  stub nodenv 'rehash : true'
   fake_env_for_npm install @org/testdouble latest
 
   run ./libexec/nodenv-rehash
 
   assert_success
-  assert_output "rehashing"
   unstub nodenv
 }


### PR DESCRIPTION
When a package is installed or uninstalled with a version spec (like 
foo@latest or foo@1.2.3), the version spec is included in the argv blob. So
in order to match against the package name, we need to allow for the 
version spec to exist (instead of matching up to the close bracket, match
to closing bracket _or_ @ sigil).

Also simplify tests by relying on the mock

The unstub action will validate that the stub was invoked as expected. If
the stub was not invoked, `unstub` will fail, so we don't need to assert
the stub invocation by matching output.

fixes #24