### PR TITLE
Ensure error during rehash doesn't fail the hook

### DIFF
--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 
-main_package() {
-  local current_package='\["'${npm_package_name:?}'("\]|@)'
+: "${npm_config_argv:=}"
+: "${npm_package_name:=}"
 
-  [[ ${npm_config_argv:?} =~ $current_package ]]
+warn() {
+  echo "${1:-$(cat -)}" >&2
+}
+
+error() {
+  warn "nodenv-package-rehash: $1"
+}
+
+main_package() {
+  if [ -z "$npm_package_name" ] || [ -z "$npm_config_argv" ]; then
+    error "can't determine target package"
+    return 0 # still rehash by default
+  fi
+
+  local current_package='\["'$npm_package_name'("\]|@)'
+  [[ $npm_config_argv =~ $current_package ]]
 }
 
 # This hook gets invoked when installing dependencies, too, but

--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -4,7 +4,7 @@
 : "${npm_package_name:=}"
 
 warn() {
-  echo "${1:-$(cat -)}" >&2
+  echo "${1-$(cat -)}" >&2
 }
 
 error() {
@@ -28,4 +28,5 @@ if ! main_package; then
   exit
 fi
 
-nodenv rehash
+nodenv rehash || error "error rehashing; manual \`nodenv rehash' likely needed"
+exit 0

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -7,7 +7,7 @@ libexec=${BATS_TEST_DIRNAME}/../libexec
 fake_env_for_npm() {
   export npm_lifecycle_event=post$1
   export npm_package_name=$2
-  export npm_package_version=$3
+  export npm_package_version=${3-latest}
 
   local p=$2${3+@$3}
   export npm_config_argv='{"remain":["'$p'"],"cooked":["i","--global","'$p'"],"original":["i","-g","'$p'"]}'
@@ -61,5 +61,16 @@ fake_env_for_npm() {
   run ./libexec/nodenv-rehash
 
   assert_success
+  unstub nodenv
+}
+
+@test "npm hook still rehashes and exits cleanly when missing vars" {
+  stub nodenv 'rehash : true'
+  unset npm_package_name npm_package_version npm_config_argv
+
+  run ./libexec/nodenv-rehash
+
+  assert_success
+  assert_line "nodenv-package-rehash: can't determine target package"
   unstub nodenv
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -71,6 +71,17 @@ fake_env_for_npm() {
   run ./libexec/nodenv-rehash
 
   assert_success
-  assert_line "nodenv-package-rehash: can't determine target package"
+  assert_output "nodenv-package-rehash: can't determine target package"
+  unstub nodenv
+}
+
+@test "npm hook exits cleanly even if nodenv-rehash errors" {
+  stub nodenv 'rehash : false'
+  fake_env_for_npm install teenytest
+
+  run ./libexec/nodenv-rehash
+
+  assert_success
+  assert_output "nodenv-package-rehash: error rehashing; manual \`nodenv rehash' likely needed"
   unstub nodenv
 }


### PR DESCRIPTION
To ensure the npm install/uninstall command itself isn't rolled back, be
absolutely sure that the hook script exits cleanly. If the rehash fails,
report it but exit 0.

Instead of erroring on missing vars, just emit a warning message.
Additionally, instead of defaulting to doing nothing in this error case, we
may as well still rehash. We could be doing more work than is necessary,
but it is an error case at that point after all. May as well be maximally
useful about it.

fixes #27