### PR TITLE
Warn about buggy npm versions

### DIFF
--- a/etc/nodenv.d/install/install-pkg-hooks.bash
+++ b/etc/nodenv.d/install/install-pkg-hooks.bash
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
 after_install install_hook_scripts
+after_install warn_buggy_npm
 
 install_hook_scripts() {
   # only install hooks after successfull node installation
@@ -8,4 +9,24 @@ install_hook_scripts() {
 
   nodenv-package-hooks install "$VERSION_NAME"
   echo "Installed postinstall/postuninstall package hooks for $VERSION_NAME"
+}
+
+buggy_npm_version() {
+  # v8.2.0 - v10.2.1
+  local bad_versions='^((8\.([2-9]|10|11))|9|(10\.[0-2])\.)'
+
+  [[ "$VERSION_NAME" =~ $bad_versions ]]
+}
+
+warn_buggy_npm() {
+  ! buggy_npm_version || cat <<- MSG
+
+WARNING: Automatic rehashing provided by nodenv-package-rehash will not
+function correctly for this node version unless you upgrade npm >=6.1.0.
+    NODENV_VERSION=$VERSION_NAME npm i -g npm@latest
+Otherwise, you will need to run \`nodenv rehash' manually after installing
+global packages. see https://github.com/nodenv/nodenv-package-rehash/issues/22
+(This node bundles a buggy npm that doesn't execute global hooks.)
+
+MSG
 }

--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -3,6 +3,7 @@
 : "${npm_config_argv:=}"
 : "${npm_package_name:=}"
 : "${npm_package_version:=}"
+: "${npm_lifecycle_event:=}"
 
 warn() {
   echo "${1-$(cat -)}" >&2
@@ -23,7 +24,7 @@ main_package() {
 }
 
 installing_npm() {
-  test "$npm_package_name" = npm
+  [ "$npm_package_name" = npm ] && [ "$npm_lifecycle_event" = postinstall ]
 }
 
 buggy_npm_version() {

--- a/libexec/nodenv-rehash
+++ b/libexec/nodenv-rehash
@@ -2,6 +2,7 @@
 
 : "${npm_config_argv:=}"
 : "${npm_package_name:=}"
+: "${npm_package_version:=}"
 
 warn() {
   echo "${1-$(cat -)}" >&2
@@ -21,11 +22,35 @@ main_package() {
   [[ $npm_config_argv =~ $current_package ]]
 }
 
+installing_npm() {
+  test "$npm_package_name" = npm
+}
+
+buggy_npm_version() {
+  # 5.1.0 - 6.0.1
+  local buggy_versions='^(5\.[1-9]|6\.0)'
+  [[ "$npm_package_version" =~ $buggy_versions ]]
+}
+
+
 # This hook gets invoked when installing dependencies, too, but
 # we only care about the "main" package installed specifically by the user.
 # That way we only rehash once for a global install, not hundreds of times.
 if ! main_package; then
   exit
+fi
+
+if installing_npm && buggy_npm_version; then
+  warn <<-MSG
+
+		WARNING: Automatic rehashing provided by nodenv-package-rehash will not work
+		for this version of npm since it doesn't execute global hooks.
+		You will need to install a version of npm <5.1.0 || >=6.1.0.
+		    npm i -g npm@latest
+		Otherwise, you will need to run \`nodenv rehash' manually after installing
+		global packages. see https://github.com/nodenv/nodenv-package-rehash/issues/22
+
+MSG
 fi
 
 nodenv rehash || error "error rehashing; manual \`nodenv rehash' likely needed"

--- a/test/install.bats
+++ b/test/install.bats
@@ -22,3 +22,17 @@ load test_helper
   refute_line 'Installed postinstall/postuninstall package hooks for 0.10.36'
   refute_package_hooks 0.10.36
 }
+
+@test "installing a node with buggy npm (8.2.0-10.2.1) emits warning" {
+  run nodenv install 8.2.0
+
+  assert_success
+  assert_line "(This node bundles a buggy npm that doesn't execute global hooks.)"
+}
+
+@test "installing a node with non-buggy npm (8.2.0-10.2.1) doesn't emit warning" {
+  run nodenv install 10.3.0
+
+  assert_success
+  refute_line -p "buggy npm"
+}

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -107,3 +107,14 @@ fake_env_for_npm() {
   refute_line -p "WARNING: Automatic rehashing"
   unstub nodenv
 }
+
+@test "npm hook doesn't warn when _uninstalling_ npm" {
+  stub nodenv 'rehash : true'
+  fake_env_for_npm uninstall npm 5.10.0
+
+  run $libexec/nodenv-rehash
+
+  assert_success
+  refute_line -p "WARNING: Automatic rehashing"
+  unstub nodenv
+}

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -38,7 +38,7 @@ fake_env_for_npm() {
   stub nodenv 'rehash : true'
   fake_env_for_npm install testdouble latest
 
-  run ./libexec/nodenv-rehash
+  run $libexec/nodenv-rehash
 
   assert_success
   unstub nodenv
@@ -48,7 +48,7 @@ fake_env_for_npm() {
   stub nodenv 'rehash : true'
   fake_env_for_npm install @org/testdouble
 
-  run ./libexec/nodenv-rehash
+  run $libexec/nodenv-rehash
 
   assert_success
   unstub nodenv
@@ -58,7 +58,7 @@ fake_env_for_npm() {
   stub nodenv 'rehash : true'
   fake_env_for_npm install @org/testdouble latest
 
-  run ./libexec/nodenv-rehash
+  run $libexec/nodenv-rehash
 
   assert_success
   unstub nodenv
@@ -68,7 +68,7 @@ fake_env_for_npm() {
   stub nodenv 'rehash : true'
   unset npm_package_name npm_package_version npm_config_argv
 
-  run ./libexec/nodenv-rehash
+  run $libexec/nodenv-rehash
 
   assert_success
   assert_output "nodenv-package-rehash: can't determine target package"
@@ -79,9 +79,31 @@ fake_env_for_npm() {
   stub nodenv 'rehash : false'
   fake_env_for_npm install teenytest
 
-  run ./libexec/nodenv-rehash
+  run $libexec/nodenv-rehash
 
   assert_success
   assert_output "nodenv-package-rehash: error rehashing; manual \`nodenv rehash' likely needed"
+  unstub nodenv
+}
+
+@test "npm hook warns if installing a buggy npm" {
+  stub nodenv 'rehash : true'
+  fake_env_for_npm install npm 5.10.0
+
+  run $libexec/nodenv-rehash
+
+  assert_success
+  assert_line "WARNING: Automatic rehashing provided by nodenv-package-rehash will not work"
+  unstub nodenv
+}
+
+@test "npm hook only warns if package is npm" {
+  stub nodenv 'rehash : true'
+  fake_env_for_npm install yarn 5.10.0
+
+  run $libexec/nodenv-rehash
+
+  assert_success
+  refute_line -p "WARNING: Automatic rehashing"
   unstub nodenv
 }


### PR DESCRIPTION
When installing a node that bundles with a buggy npm, warn that the
auto-rehashing won't work.

When installing a buggy version of npm (as in when "upgrading" from npm4
to 5), warn that auto-rehashing won't work.

closes #22