### PR TITLE
local npm postinstall hook to install nodenv hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,79 @@ runs `nodenv rehash` every time you install or uninstall a global package.
 <!-- toc -->
 
 - [Installation](#installation)
-  * [Tweak nodenv installation *(optional)*](#tweak-nodenv-installation-optional)
+  * [install via git *(recommended)*](#install-via-git-recommended)
+  * [install via homebrew](#install-via-homebrew)
+  * [install via npm](#install-via-npm)
+- [Configuration *(optional)*](#configuration-optional)
 - [Usage](#usage)
   * [Subcommands](#subcommands)
 - [How It Works](#how-it-works)
+- [Caveats](#caveats)
 - [Credits](#credits)
 
 <!-- tocstop -->
 
 ## Installation
 
-Install the plugin:
+After installation, you should have a `nodenv package-hooks` subcommand,
+and the package-rehash hook should be included in the output of
+`nodenv hooks install`.
 
-    git clone https://github.com/nodenv/nodenv-package-rehash.git "$(nodenv root)"/plugins/nodenv-package-rehash
-
-Install hooks for your existing nodenv versions.
+Then you may install the hooks for your existing nodenv versions.
 (This will be done automatically for any node you install henceforth.)
 
-    nodenv package-hooks install --all
+  ```sh
+  nodenv package-hooks install --all
+  ```
 
-### Tweak nodenv installation *(optional)*
+### install via git *(recommended)*
+
+Install the plugin:
+
+  ```sh
+  git clone https://github.com/nodenv/nodenv-package-rehash.git "$(nodenv root)"/plugins/nodenv-package-rehash
+  ```
+
+### install via homebrew
+
+  ```sh
+  brew install nodenv/nodenv/nodenv-package-rehash
+  ```
+
+### install via npm
+
+  ```sh
+  npm i -g @nodenv/nodenv-package-rehash
+  ```
+
+This method is not recommended, because of the likelihood that the nodenv plugin gets installed under a node being _managed_ by nodenv.
+If using this method, it is highly recommended to install the plugin into your `system` node.
+
+Also note, this package requires a package level npm postinstall hook to ensure the nodenv-install hook is found by `nodenv hooks install`.
+If you install this package with lifecycle hooks disabled, you will need to do this manually either by a one-time symlink:
+
+  ```sh
+  ln -s "$(npm -g prefix)/lib/node_modules/@nodenv/nodenv-package-rehash/etc/nodenv.d/install/install-pkg-hooks.bash" "$(nodenv root)/nodenv.d/install/package-rehash.bash
+  ```
+
+or by configuring `NODENV_HOOK_PATH` in your shell startup:
+
+  ```sh
+  export NODENV_HOOK_PATH=$(npm -g prefix)/lib/node_modules/@nodenv/nodenv-package-rehash/etc/nodenv.d/:$NODENV_HOOK_PATH
+  ```
+
+## Configuration *(optional)*
 
 With this plugin, rehashing will happen on-demand (when global npm modules are installed/uninstalled).
-You can take advantage of this and remove nodenv's _automatic_ hashing upon [shell initialization](https://github.com/nodenv/nodenv#how-nodenv-hooks-into-your-shell).
+You can take advantage of this and remove nodenv's _automatic_ hashing upon [shell initialization][].
 In your shell startup file (`.bash_profile`, `.bashrc`, or `.zshrc`), add the `--no-rehash` flag to the `nodenv init -` invocation:
 
-    eval "$(nodenv init - --no-rehash)"
-    
+  ```sh
+  eval "$(nodenv init - --no-rehash)"
+  ```
+
 This will speed up your shell initialization since nodenv will no longer need to rehash on every startup.
-    
+
 ## Usage
 
 1. `npm install -g` a package that provides executables.
@@ -60,27 +104,43 @@ Three sub commands are available for manual hook management.
 
 All three sub commands accept similar arguments:
 
-1. no arg: applies the command only to the currently active node version (regardless how that version is set)
+1. no arg: applies the command only to the currently active node version
 2. version-name: a whitespace-separate list of 1 or more explicit versions (e.g. 0.10.24)
 3. `--all`: applies the command to all installed versions
 
 
 ## How It Works
 
-nodenv-package-rehash consists of two parts: an npm postinstall (and
-postuninstall) hook script and a nodenv plugin.
+nodenv-package-rehash consists of two parts:
+an npm postinstall (and postuninstall) hook script and a nodenv plugin.
 
-The npm script hooks into npm's `postinstall` and `postuninstall` lifecycle
-events (corresponding to `npm install -g` and `npm uninstall -g`) to run
-`nodenv rehash`, ensuring newly installed package executables are visible to
-nodenv.
+The npm script hooks into npm's `postinstall` and `postuninstall` lifecycle events
+(corresponding to `npm install -g` and `npm uninstall -g`) to run `nodenv rehash`,
+ensuring newly installed package executables are visible to nodenv.
 
-The nodenv plugin is responsible for installing the npm hook script. It
-relies on nodenv's `install` hook to copy the hook script into node's global
-`node_modules/hooks`.
+The nodenv plugin is responsible for installing the npm hook script.
+It relies on nodenv's `install` hook to copy the npm hook script into node's global `node_modules/.hooks/`.
+
+For users who install this plugin via npm, there is also a package postinstall hook
+which will install the nodenv-install hook into the `NODENV_HOOK_PATH`.
+
+## Caveats
+
+Automatic rehashing after installation of global packages does _not_ work with versions of npm `^5.1.0 || ~6.0.1`.
+If you use one of the affected versions of npm,
+you will need to run `nodenv rehash` manually after installing global packages.
+It is recommended to upgrade to a version of npm 6.1.0 or later (or stay on a version prior to 5.1.0).
+
+npm version 5.1.0 [broke global package hooks][issue] ([npm/cli@e084987][npm-cli]) and they remained broken until 6.1.0 ([npm/npm-lifecycle#13][npm-lifecycle]).
+Node versions 8.2.0 through 10.2.1 (inclusive) ship with affected versions of npm.
 
 ## Credits
 
-Forked from [Joshua Peek](https://github.com/josh)'s
-[rbenv-gem-rehash](https://github.com/rbenv/rbenv-gem-rehash) by 
-[Jason Karns](https://github.com/jasonkarns) and modified for nodenv.
+Inspired by [Joshua Peek][]'s [rbenv-gem-rehash][].
+
+[Joshua Peek]: https://github.com/josh
+[shell initialization]: https://github.com/nodenv/nodenv#how-nodenv-hooks-into-your-shell
+[rbenv-gem-rehash]: https://github.com/rbenv/rbenv-gem-rehash
+[issue]: https://npm.community/t/npm-version-5-broke-local-and-global-lifecycle-hooks/4857
+[npm-cli]: https://github.com/npm/cli/commit/e084987
+[npm-lifecycle]: https://github.com/npm/npm-lifecycle/pull/13

--- a/libexec/install-nodenv-hook
+++ b/libexec/install-nodenv-hook
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${npm_config_argv:=}"
+: "${NODENV_HOOK_PATH:=}"
+
+# detect when `npm install` is run from within the package
+bare_install() {
+  local pattern='"remain":\[\]'
+  [[ $npm_config_argv =~ $pattern ]]
+}
+
+hooks_dir() {
+  local hook_dir=${NODENV_HOOK_PATH#:}
+  hook_dir=${hook_dir%%:*}
+  echo "${hook_dir:-$(nodenv root)/nodenv.d}"
+}
+
+link_hook() {
+  local dir hook
+  hook=etc/nodenv.d/install/install-pkg-hooks.bash
+  dir=$(hooks_dir)/install
+
+  mkdir -p "$dir"
+  ln -sf "$PWD/$hook" "$dir/package-rehash.bash"
+}
+
+if ! bare_install; then
+  link_hook
+  echo "nodenv install hook installed to $(hooks_dir)"
+fi

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "libexec"
   ],
   "scripts": {
+    "postinstall": "libexec/install-nodenv-hook",
     "start": "npm-packages-rehash",
     "test": "bats ${CI:+--tap} test",
     "posttest": "npm run lint",

--- a/test/hook-dir.bats
+++ b/test/hook-dir.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+libexec=$BATS_TEST_DIRNAME/../libexec
+
+fake_npm_env() {
+  export npm_config_argv='{"remain":["@nodenv/nodenv-package-rehash"],"cooked":["i","@nodenv/nodenv-package-rehash"],"original":["i","@nodenv/nodenv-package-rehash"]}'
+  cd $BATS_TEST_DIRNAME/..
+}
+
+assert_nodenv_hook_installed() {
+  [ -L "$1/install/package-rehash.bash" ]
+}
+
+@test "npm doesn't install nodenv hook when running bare install" {
+  fake_npm_env
+  npm_config_argv='{"remain":[],"cooked":["i"],"original":["i"]}'
+
+  run $libexec/install-nodenv-hook
+
+  assert_success
+  refute_output
+}
+
+@test "npm installs nodenv hook to NODENV_HOOK_PATH when set" {
+  fake_npm_env
+  export NODENV_HOOK_PATH=$BATS_TMPDIR/hooks
+  mkdir -p $NODENV_HOOK_PATH
+
+  run $libexec/install-nodenv-hook
+
+  assert_success
+  assert_nodenv_hook_installed "$NODENV_HOOK_PATH"
+  assert_output "nodenv install hook installed to $NODENV_HOOK_PATH"
+}
+
+@test "npm installs nodenv hook to NODENV_ROOT/nodenv.d when NODENV_HOOK_PATH not set" {
+  fake_npm_env
+  unset NODENV_HOOK_PATH
+
+  run $libexec/install-nodenv-hook
+
+  assert_success
+  assert_nodenv_hook_installed "$NODENV_ROOT/nodenv.d"
+  assert_output "nodenv install hook installed to $NODENV_ROOT/nodenv.d"
+}

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-libexec=${BATS_TEST_DIRNAME}/../libexec
+libexec=$BATS_TEST_DIRNAME/../libexec
 
 fake_env_for_npm() {
   export npm_lifecycle_event=post$1


### PR DESCRIPTION
Install nodenv-install hook during npm install

If this package is being installed via npm (instead of homebrew or 
git-clone), the nodenv hook will need added to NODENV_HOOK_PATH.

This npm postinstall hook does this automatically. (Preferring 
NODENV_HOOK_PATH if set; $(nodenv root)/nodenv.d, otherwise.)

closes #26 